### PR TITLE
Add ability to randomly sort gallery items on each load

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ recursive: true      # optional: true | false
 limit: 10            # optional: 0 | any number
 sort: desc           # optional: desc | asc
 sortBy: mtime        # optional: mtime | ctime | name
+sortRandom: false    # optional: false | true - randomly sorts the cards, overrides other sorting options
 fontSize: 6pt        # optional: 6pt | NUMBERpt | NUMBERpx
 showTitle: true      # optional: true | false
 breakpoints:         # optional: allows to set breakpoints for number of columns

--- a/src/code-block/settings.ts
+++ b/src/code-block/settings.ts
@@ -8,6 +8,7 @@ export interface Settings {
   recursive: boolean;
   sort: "asc" | "desc";
   sortby: "name" | "mtime" | "ctime";
+  randomizeorder: boolean;
   fontsize: string;
   showtitle: boolean;
   debugquery: boolean;
@@ -21,6 +22,7 @@ const DEFAULT_SETTINGS: Settings = {
   recursive: true,
   sort: "desc",
   sortby: "mtime",
+  randomizeorder: false,
   fontsize: "6pt",
   showtitle: true,
   debugquery: false,

--- a/src/code-block/settings.ts
+++ b/src/code-block/settings.ts
@@ -8,7 +8,7 @@ export interface Settings {
   recursive: boolean;
   sort: "asc" | "desc";
   sortby: "name" | "mtime" | "ctime";
-  randomizeorder: boolean;
+  sortrandom: boolean;
   fontsize: string;
   showtitle: boolean;
   debugquery: boolean;
@@ -22,7 +22,7 @@ const DEFAULT_SETTINGS: Settings = {
   recursive: true,
   sort: "desc",
   sortby: "mtime",
-  randomizeorder: false,
+  sortrandom: false,
   fontsize: "6pt",
   showtitle: true,
   debugquery: false,

--- a/src/react/utils/use-files.ts
+++ b/src/react/utils/use-files.ts
@@ -205,7 +205,9 @@ export const useFiles = () => {
       const allFiles = [...files, ...reloadPathFiles(), ...reloadQueryFiles(update)];
       const newFiles = [...new Map(allFiles.map(file => [file.path, file])).values()];
       const filteredFiles = filterFileList(newFiles, db, sourcePath, settings, randomSeed.current);
-      setFiles(filteredFiles);
+      if (filteredFiles.length) {
+        setFiles(filteredFiles);
+      }
     };
     if (!files.length) reloadFiles(embeddedSearch?.dom, true);
 

--- a/src/react/utils/use-files.ts
+++ b/src/react/utils/use-files.ts
@@ -78,6 +78,7 @@ const filterFileList = (
   db: Database<dbHTMLEntry>,
   sourcePath: string,
   settings: Settings,
+  randomSeed: number = 50,
 ) => {
   const filteredFiles = files
     .filter(
@@ -113,7 +114,9 @@ const filterFileList = (
       const sort = settings.sort === "asc" ? -1 : 1;
       return refA < refB ? sort : refA > refB ? sort * -1 : 0;
     });
-  return settings.limit === 0 ? filteredFiles : filteredFiles.splice(0, settings.limit);
+
+  const sortedFiles = settings.sortrandom === true ? deterministicShuffle(filteredFiles, randomSeed) : filteredFiles;
+  return settings.limit === 0 ? sortedFiles : sortedFiles.splice(0, settings.limit);
 };
 
 const getSortOrder = (settings: Settings) => {
@@ -201,14 +204,8 @@ export const useFiles = () => {
       // deduplicate by file.path, keeping the newest ones
       const allFiles = [...files, ...reloadPathFiles(), ...reloadQueryFiles(update)];
       const newFiles = [...new Map(allFiles.map(file => [file.path, file])).values()];
-      const filteredFiles = filterFileList(newFiles, db, sourcePath, settings);
-      if (filteredFiles.length) {
-        if (settings.randomizeorder) {
-          setFiles(deterministicShuffle(filteredFiles, randomSeed.current))
-        } else {
-          setFiles(filteredFiles);
-        }
-      }
+      const filteredFiles = filterFileList(newFiles, db, sourcePath, settings, randomSeed.current);
+      setFiles(filteredFiles);
     };
     if (!files.length) reloadFiles(embeddedSearch?.dom, true);
 


### PR DESCRIPTION
This was requested in https://github.com/pashashocky/obsidian-note-gallery/issues/42 and was a feature I wanted for myself.

It will randomly sort the cards each time you close and re-open the file. It overrides any other sorting parameters provided. 

